### PR TITLE
Fixed Bug

### DIFF
--- a/src/main/java/commandHandling/commands/publicCommands/LetMeGoogleThatForYou.java
+++ b/src/main/java/commandHandling/commands/publicCommands/LetMeGoogleThatForYou.java
@@ -32,7 +32,6 @@ public class LetMeGoogleThatForYou implements CommandInterface {
             CommandContext ctxT = ctx;
             String id = ctx.getMessage().getId();
             String input = ctxT.getArguments().size() == 0 ? "lorem ipsum" : ctxT.getArguments().stream().map(Object::toString).collect(Collectors.joining(" "));
-            String searchURL = ctxT.getArguments().stream().map(Object::toString).collect(Collectors.joining("+"));
 
             try {
                 ImageOutputStream output = new FileImageOutputStream(new File("tempFiles/lmgtfy" + id + ".gif"));
@@ -98,7 +97,7 @@ public class LetMeGoogleThatForYou implements CommandInterface {
             File gif = new File("tempFiles/lmgtfy" + id + ".gif");
 
             EmbedBuilder embed = EmbedHelper.embedBuilder("Let Me Google That For You");
-            embed.setDescription("[Google](https://www.google.com/search?q=" + searchURL + ")");
+            embed.setDescription("[Google](https://www.google.com/search?q=" + input + ")");
             embed.setImage("attachment://lmgtfy" + id + ".gif");
 
             ctxT.getChannel().sendMessageEmbeds(embed.build()).addFile(gif).queue(

--- a/src/main/java/commandHandling/commands/publicCommands/LetMeGoogleThatForYou.java
+++ b/src/main/java/commandHandling/commands/publicCommands/LetMeGoogleThatForYou.java
@@ -32,6 +32,7 @@ public class LetMeGoogleThatForYou implements CommandInterface {
             CommandContext ctxT = ctx;
             String id = ctx.getMessage().getId();
             String input = ctxT.getArguments().size() == 0 ? "lorem ipsum" : ctxT.getArguments().stream().map(Object::toString).collect(Collectors.joining(" "));
+            String searchURL = ctxT.getArguments().size() == 0 ? "lorem+ipsum" : ctxT.getArguments().stream().map(Object::toString).collect(Collectors.joining("+"));
 
             try {
                 ImageOutputStream output = new FileImageOutputStream(new File("tempFiles/lmgtfy" + id + ".gif"));
@@ -97,7 +98,7 @@ public class LetMeGoogleThatForYou implements CommandInterface {
             File gif = new File("tempFiles/lmgtfy" + id + ".gif");
 
             EmbedBuilder embed = EmbedHelper.embedBuilder("Let Me Google That For You");
-            embed.setDescription("[Google](https://www.google.com/search?q=" + input + ")");
+            embed.setDescription("[Google](https://www.google.com/search?q=" + searchURL + ")");
             embed.setImage("attachment://lmgtfy" + id + ".gif");
 
             ctxT.getChannel().sendMessageEmbeds(embed.build()).addFile(gif).queue(


### PR DESCRIPTION
If input is empty, the resulting gif would have the alternative text "lorem ipsum" the resulting link in the embed would have been "[Google](https://www.google.com/search?q=)" though. This is not consistent and if you would want to have just google.com as link if the input is empty, I would advise removing the "search?q=" even if it works with it.